### PR TITLE
authenticate to ghcr

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,6 +36,8 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REGISTRY_USER: ${{ github.actor }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx \
             --package @codedependant/semantic-release-docker@4 \

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,8 +8,7 @@
       {
         "dockerRegistry": "ghcr.io",
         "dockerProject": "koterpillar",
-        "dockerImage": "multiblog",
-        "dockerTags": ["latest", "{{version}}"]
+        "dockerImage": "multiblog"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
- **Remove manually set Docker tags (default is OK)**
- **fix: Authenticate to GitHub container registry when publishing**
